### PR TITLE
Minimalistic lint command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ linters-settings:
           - embed
           - time
           - strconv
+          - slices
+          - sort
           - regexp
           - encoding/json
           - testing

--- a/internal/cmd/lint.go
+++ b/internal/cmd/lint.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/servletcloud/Andmerada/internal/osutil"
@@ -109,13 +108,10 @@ func printLintError(err source.LintError) {
 }
 
 func sortLintErrorsByIDAsc(errors []source.LintError) {
-	sort.Slice(errors, func(i int, j int) bool {
-		err1 := errors[i]
-		err2 := errors[j]
+	slices.SortFunc(errors, func(a, b source.LintError) int {
+		slices.Sort(a.Files)
+		slices.Sort(b.Files)
 
-		slices.Sort(err1.Files)
-		slices.Sort(err2.Files)
-
-		return strings.Compare(err1.Files[0], err2.Files[0]) <= 0
+		return strings.Compare(a.Files[0], b.Files[0])
 	})
 }

--- a/internal/cmd/lint.go
+++ b/internal/cmd/lint.go
@@ -1,8 +1,20 @@
 package cmd
 
 import (
+	"log"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/servletcloud/Andmerada/internal/osutil"
 	"github.com/servletcloud/Andmerada/internal/resources"
+	"github.com/servletcloud/Andmerada/internal/source"
 	"github.com/spf13/cobra"
+)
+
+const (
+	exitCodeLintErrors = 1
 )
 
 func lintCommand() *cobra.Command {
@@ -14,7 +26,96 @@ func lintCommand() *cobra.Command {
 		Short: description.Short,
 		Long:  description.Long,
 		Run: func(_ *cobra.Command, _ []string) {
+			currentDir := osutil.GetwdOrPanic()
 
+			ensureProjectInitialized(currentDir)
+
+			log.Println("Validating the migration files, please, wait...")
+
+			report := source.LintReport{}
+			if err := source.Lint(currentDir, &report); err != nil {
+				log.Panic(err)
+			}
+
+			printLintReport(&report)
+
+			if len(report.Errors) > 0 {
+				os.Exit(exitCodeLintErrors)
+			}
 		},
 	}
+}
+
+func printLintReport(report *source.LintReport) {
+	if len(report.Errors) == 0 {
+		log.Println("✔️ All checks passed. No issues found.")
+
+		return
+	}
+
+	criticalCount := len(report.Errors)
+	warningCount := len(report.Warings)
+
+	log.Println("Lint Report:")
+
+	if criticalCount > 0 {
+		log.Printf("%d Critical Errors:\n", criticalCount)
+
+		sortLintErrorsByIDAsc(report.Errors)
+
+		for _, err := range report.Errors {
+			printLintError(err)
+		}
+	}
+
+	if warningCount > 0 {
+		log.Printf("%d Warnings:\n", warningCount)
+
+		sortLintErrorsByIDAsc(report.Warings)
+
+		for _, err := range report.Warings {
+			printLintError(err)
+		}
+	}
+
+	log.Printf(" Summary: Critical Errors: %d, Warnings: %d", criticalCount, warningCount)
+
+	if criticalCount > 0 {
+		log.Println("  ⚠️ Critical errors detected. 'andmerada migrate' will fail to run these migrations.")
+	}
+}
+
+func printLintError(err source.LintError) {
+	log.Printf("  - %s\n", err.Title)
+
+	if len(err.Details) > 0 {
+		log.Printf("    Details: %s\n", err.Details)
+	}
+
+	if len(err.Files) > 0 {
+		skip := false
+
+		if len(err.Files) == 1 {
+			file := err.Files[0]
+			skip = strings.Contains(err.Details, file) || strings.Contains(err.Title, file)
+		}
+
+		if !skip {
+			log.Printf("    Affected Files: %s\n", err.Files)
+		}
+	}
+
+	log.Println()
+}
+
+func sortLintErrorsByIDAsc(errors []source.LintError) {
+	sort.Slice(errors, func(i int, j int) bool {
+		err1 := errors[i]
+		err2 := errors[j]
+
+		slices.Sort(err1.Files)
+		slices.Sort(err2.Files)
+
+		return strings.Compare(err1.Files[0], err2.Files[0]) <= 0
+	})
 }

--- a/internal/resources/command_lint_description.txt
+++ b/internal/resources/command_lint_description.txt
@@ -3,6 +3,5 @@ Validate migration files
 Validates that the migration files have correct syntax and can be run. Correct syntax means that the configuration files, such as 'andmerada.yml' and 'migration.yml', adhere to their schemas, and that referenced SQL scripts exist and are accessible. It does not check the SQL.
 
 Exit Codes:
-  - Exit code 2: Indicates critical errors that will cause 'andmerada migrate' to fail.
-  - Exit code 1: Indicates warnings; 'andmerada migrate' will still run.
+  - Exit code 1: Indicates critical errors that will cause 'andmerada migrate' to fail.
   - Exit code 0: No issues detected.

--- a/internal/schema/andmerada.yml.v1.json
+++ b/internal/schema/andmerada.yml.v1.json
@@ -7,6 +7,7 @@
     "name": {
       "type": "string",
       "description": "The name of the project",
+      "minLength": 1,
       "maxLength": 255
     }
   }

--- a/internal/schema/migration.yml.v1.json
+++ b/internal/schema/migration.yml.v1.json
@@ -7,6 +7,7 @@
     "name": {
       "type": "string",
       "description": "The name of the migration",
+      "minLength": 1,
       "maxLength": 255
     },
     "up": {
@@ -23,7 +24,7 @@
     "down": {
       "type": "object",
       "description": "Configuration for the down migration",
-      "required": ["file"],
+      "required": ["file", "block"],
       "properties": {
         "file": {
           "type": "string",
@@ -31,8 +32,7 @@
         },
         "block": {
           "type": "boolean",
-          "description": "Whether the down migration is blocked",
-          "default": false
+          "description": "Whether the down migration is blocked"
         },
         "block_reason": {
           "type": "string",

--- a/internal/source/linter.go
+++ b/internal/source/linter.go
@@ -1,0 +1,60 @@
+package source
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/servletcloud/Andmerada/internal/schema"
+	"github.com/servletcloud/Andmerada/internal/ymlutil"
+	"gopkg.in/yaml.v3"
+)
+
+func lint(projectDir string, report *LintReport) error {
+	configurations := make([]Configuration, 0)
+
+	err := scan(projectDir, func(_ MigrationID, name string) bool {
+		relativePath := filepath.Join(name, MigrationYmlFilename)
+		configuration, err := loadConfiguration(filepath.Join(projectDir, relativePath))
+
+		if err == nil {
+			configurations = append(configurations, configuration)
+		} else {
+			report.Errors = append(report.Errors, configurationErrorToLint(relativePath, err))
+		}
+
+		return true
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadConfiguration(path string) (Configuration, error) {
+	var configuration Configuration
+
+	err := ymlutil.LoadFromFile(path, schema.GetMigrationSchema(), &configuration)
+
+	// Intentionally avoid wrapping errors to ensure clean and actionable messages in lint output.
+	return configuration, err //nolint:wrapcheck
+}
+
+func configurationErrorToLint(file string, err error) LintError {
+	title := "Failed to read, parse, or validate the migration file"
+	details := err.Error()
+
+	if errors.Is(err, os.ErrNotExist) {
+		title = fmt.Sprintf("Migration file does not exist: %q", file)
+		details = ""
+	} else if errors.Is(err, ymlutil.ErrSchemaValidation) {
+		title = "Schema validation failed"
+	} else if yamlError := new(yaml.TypeError); errors.As(err, &yamlError) {
+		title = "Invalid YAML"
+	}
+
+	return LintError{Files: []string{file}, Title: title, Details: details}
+}

--- a/internal/source/linter_test.go
+++ b/internal/source/linter_test.go
@@ -1,0 +1,103 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/servletcloud/Andmerada/internal/osutil"
+	"github.com/servletcloud/Andmerada/internal/project"
+	"github.com/servletcloud/Andmerada/internal/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLint(t *testing.T) {
+	t.Parallel()
+
+	timestamp, err := time.Parse("20060102150405", "20241225112129")
+	require.NoError(t, err)
+
+	timestamp2, err := time.Parse("20060102150405", "20241226122230")
+	require.NoError(t, err)
+
+	t.Run("A project with a migration has no errors", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+
+		require.NoError(t, project.Initialize(dir))
+
+		_, err := source.Create(dir, "Create users table", timestamp)
+		require.NoError(t, err)
+
+		report := runLint(dir)
+
+		assert.Empty(t, report.Errors)
+		assert.Empty(t, report.Warings)
+
+		t.Run("No migration.yml file", func(t *testing.T) {
+			migrationDir := createTempMigration(t, dir, timestamp2)
+			path := filepath.Join(dir, migrationDir, "migration.yml")
+			require.NoError(t, os.Remove(path))
+
+			report := runLint(dir)
+
+			assertHasError(t, report, "Migration file does not exist")
+		})
+
+		t.Run("migration.yml violates the schema", func(t *testing.T) {
+			migrationDir := createTempMigration(t, dir, timestamp2)
+			path := filepath.Join(dir, migrationDir, "migration.yml")
+			require.NoError(t, os.WriteFile(path, []byte("---"), osutil.FilePerm0644))
+
+			report := runLint(dir)
+
+			assertHasError(t, report, "Schema validation failed")
+		})
+
+		t.Run("migration.yml has invalid syntax", func(t *testing.T) {
+			migrationDir := createTempMigration(t, dir, timestamp2)
+			path := filepath.Join(dir, migrationDir, "migration.yml")
+			require.NoError(t, os.WriteFile(path, []byte("bad yaml"), osutil.FilePerm0644))
+
+			report := runLint(dir)
+
+			assertHasError(t, report, "Invalid YAM")
+		})
+	})
+}
+
+func createTempMigration(t *testing.T, dir string, timestamp time.Time) string {
+	t.Helper()
+
+	result, err := source.Create(dir, "Create a bad table", timestamp)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(filepath.Join(dir, result.BaseDir))
+		require.NoError(t, err)
+	})
+
+	return result.BaseDir
+}
+
+func assertHasError(t *testing.T, report *source.LintReport, expectedTitle string) {
+	t.Helper()
+
+	require.Len(t, report.Errors, 1)
+
+	lintError := report.Errors[0]
+	assert.Contains(t, lintError.Title, expectedTitle)
+}
+
+func runLint(dir string) *source.LintReport {
+	report := new(source.LintReport)
+
+	if err := source.Lint(dir, report); err != nil {
+		panic(err)
+	}
+
+	return report
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -12,6 +12,33 @@ type CreateSourceResult struct {
 
 type MigrationID uint64
 
+type LintError struct {
+	Files   []string
+	Title   string
+	Details string
+}
+
+type LintReport struct {
+	Errors  []LintError
+	Warings []LintError
+}
+
+type Configuration struct {
+	Name string `yaml:"name"`
+
+	Up struct {
+		File string `yaml:"file"`
+	}
+
+	Down struct {
+		File        string `yaml:"file"`
+		Block       bool   `yaml:"block"`
+		BlockReason string `yaml:"block_reason"` //nolint:tagliatelle
+	}
+
+	Meta map[string]interface{} `yaml:"meta"`
+}
+
 const (
 	MaxNameLength = 255
 
@@ -37,6 +64,10 @@ func NewIDFromString(str string) MigrationID {
 
 func Create(projectDir string, name string, time time.Time) (CreateSourceResult, error) {
 	return create(projectDir, name, time)
+}
+
+func Lint(projectDir string, report *LintReport) error {
+	return lint(projectDir, report)
 }
 
 func Scan(projectDir string, callback func(id MigrationID, name string) bool) error {


### PR DESCRIPTION
Example
```
[vlad@fedora Andmerada]$ bin/andmerada lint
2025/01/03 21:39:39 Validating the migration files, please, wait...
2025/01/03 21:39:39 Lint Report:
2025/01/03 21:39:39 2 Critical Errors:
2025/01/03 21:39:39   - Schema validation failed
2025/01/03 21:39:39     Details: cannot validate schema in "/home/vlad/Andmerada/20250103165601_add_users_table/migration.yml" because Validation failed with the following errors:
- (root): name is required
: cannot validate schema
2025/01/03 21:39:39
2025/01/03 21:39:39   - Migration file does not exist: "20250103165602_add_users_table copy/migration.yml"
2025/01/03 21:39:39
2025/01/03 21:39:39  Summary: Critical Errors: 2, Warnings: 0
2025/01/03 21:39:39   ⚠️ Critical errors detected. 'andmerada migrate' will fail to run these migrations.
```

Implemented validations:
- [x] No project, or project can not be open, parsed, validated
- [x] For each migration: no `migration.yml`, or it can not be open, parsed, validated