### PR TITLE
Add linter rule to check the referenced SQL files

### DIFF
--- a/internal/resources/template.migration.yml
+++ b/internal/resources/template.migration.yml
@@ -5,10 +5,10 @@
 name: "{{name}}"
 
 up:
-  file: ./up.sql
+  file: up.sql
 
 down:
-  file: ./down.sql
+  file: down.sql
   block: false
   block_reason: "This migration contains irreversible changes."
 

--- a/internal/schema/migration.yml.v1.json
+++ b/internal/schema/migration.yml.v1.json
@@ -24,7 +24,7 @@
     "down": {
       "type": "object",
       "description": "Configuration for the down migration",
-      "required": ["file", "block"],
+      "required": ["block"],
       "properties": {
         "file": {
           "type": "string",
@@ -40,7 +40,17 @@
           "maxLength": 255,
           "default": "This migration contains irreversible changes."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "block": { "const": false } }
+          },
+          "then": {
+            "required": ["file"]
+          }
+        }
+      ]
     },
     "meta": {
       "type": "object",

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -28,13 +28,13 @@ type Configuration struct {
 
 	Up struct {
 		File string `yaml:"file"`
-	}
+	} `yaml:"up"`
 
 	Down struct {
 		File        string `yaml:"file"`
 		Block       bool   `yaml:"block"`
 		BlockReason string `yaml:"block_reason"` //nolint:tagliatelle
-	}
+	} `yaml:"down"`
 
 	Meta map[string]interface{} `yaml:"meta"`
 }
@@ -72,4 +72,12 @@ func Lint(projectDir string, report *LintReport) error {
 
 func Scan(projectDir string, callback func(id MigrationID, name string) bool) error {
 	return scan(projectDir, callback)
+}
+
+func (report *LintReport) AddError(file, title, details string) {
+	report.Errors = append(report.Errors, LintError{
+		Title:   title,
+		Files:   []string{file},
+		Details: details,
+	})
 }


### PR DESCRIPTION
Example:
```
[vlad@fedora Andmerada]$ ./bin/andmerada lint
2025/01/04 11:50:17 Validating the migration files, please, wait...
2025/01/04 11:50:17 Lint Report:
2025/01/04 11:50:17 2 Critical Errors:
2025/01/04 11:50:17   - File referenced by migration.yml does not exist
2025/01/04 11:50:17     Affected Files: [20250104094701_add_users_table/down.sql]
2025/01/04 11:50:17
2025/01/04 11:50:17   - File referenced by migration.yml does not exist
2025/01/04 11:50:17     Affected Files: [20250104094701_add_users_table/up.sql]
2025/01/04 11:50:17
2025/01/04 11:50:17  Summary: Critical Errors: 2, Warnings: 0
2025/01/04 11:50:17   ⚠️ Critical errors detected. 'andmerada migrate' will fail to run these migrations.
```