### PR TITLE
Added linter for future migration

### DIFF
--- a/internal/cmd/lint.go
+++ b/internal/cmd/lint.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/dustin/go-humanize/english"
@@ -36,6 +37,7 @@ func lintCommand() *cobra.Command {
 			config := source.LintConfiguration{
 				ProjectDir:     currentDir,
 				MaxSQLFileSize: 1 * humanize.MiByte,
+				NowUTC:         time.Now().UTC(),
 			}
 			report := source.LintReport{}
 			if err := source.Lint(config, &report); err != nil {

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -42,6 +42,7 @@ type Configuration struct {
 type LintConfiguration struct {
 	ProjectDir     string
 	MaxSQLFileSize int64
+	NowUTC         time.Time
 }
 
 const (
@@ -83,6 +84,14 @@ func (report *LintReport) AddError(file, title, details string) {
 	report.Errors = append(report.Errors, LintError{
 		Title:   title,
 		Files:   []string{file},
+		Details: details,
+	})
+}
+
+func (report *LintReport) AddWarning(files []string, title, details string) {
+	report.Errors = append(report.Errors, LintError{
+		Title:   title,
+		Files:   files,
 		Details: details,
 	})
 }


### PR DESCRIPTION
Example:
```
[vlad@fedora Andmerada]$ ./bin/andmerada lint
2025/01/05 16:27:22 Validating the migration files, please, wait...
2025/01/05 16:27:22 Critical Errors:
2025/01/05 16:27:22   - There are migrations with timestamps in the future
2025/01/05 16:27:22     These migrations are pending unless already applied, regardless of their timestamps
2025/01/05 16:27:22     Affected file: 20250106142625_add_users_table
2025/01/05 16:27:22
2025/01/05 16:27:22  Summary: Critical Errors: 1, Warnings: 0
2025/01/05 16:27:22   ⚠️ Critical errors detected. 'andmerada migrate' will fail to run these migrations.
```