### PR TITLE
migrate handles the case when there is no migrations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters-settings:
           - github.com/spf13/cobra
           - github.com/dustin/go-humanize
           - github.com/jackc/pgx/v5
+          - github.com/jackc/pgerrcode
           - github.com/xeipuuv/gojsonschema
           - github.com/fergusstrange/embedded-postgres
           - github.com/servletcloud/Andmerada/internal/migrator

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fergusstrange/embedded-postgres v1.30.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/fergusstrange/embedded-postgres v1.30.0 h1:ewv1e6bBlqOIYtgGgRcEnNDpfG
 github.com/fergusstrange/embedded-postgres v1.30.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438 h1:Dj0L5fhJ9F82ZJyVOmBx6msDp/kfd1t9GRfny/mfJA0=
+github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -2,18 +2,46 @@ package migrator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/servletcloud/Andmerada/internal/migrator/sqlres"
 	"github.com/servletcloud/Andmerada/internal/project"
+	"github.com/servletcloud/Andmerada/internal/source"
 )
+
+type Report struct {
+	SourcesOnDisk int
+}
 
 type Applier struct {
 	DatabaseURL string
 	Project     project.Project
 }
 
-func (applier *Applier) ApplyPending(ctx context.Context) error {
+func (applier *Applier) ApplyPending(ctx context.Context, report *Report) error {
+	sourceIDToName := make(map[source.MigrationID]string)
+	dupeIDToName := make(map[source.MigrationID]string)
+
+	err := source.ScanAll(applier.Project.Dir, func(id source.MigrationID, name string) {
+		_, found := sourceIDToName[id]
+		if found {
+			dupeIDToName[id] = name
+		} else {
+			sourceIDToName[id] = name
+		}
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to scan migration files on disk: %w", err)
+	}
+
+	report.SourcesOnDisk = len(sourceIDToName)
+
+	if len(sourceIDToName) == 0 {
+		return nil
+	}
+
 	connection, err := pgx.Connect(ctx, applier.DatabaseURL)
 	if err != nil {
 		return &PostgresConnectError{cause: err}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -82,6 +82,14 @@ func Lint(conf LintConfiguration, report *LintReport) error {
 	return linter.lint()
 }
 
+func ScanAll(projectDir string, callback func(id MigrationID, name string)) error {
+	return scan(projectDir, func(id MigrationID, name string) bool {
+		callback(id, name)
+
+		return true
+	})
+}
+
 func Scan(projectDir string, callback func(id MigrationID, name string) bool) error {
 	return scan(projectDir, callback)
 }

--- a/internal/tests/assert.go
+++ b/internal/tests/assert.go
@@ -1,12 +1,9 @@
 package tests
 
 import (
-	"os"
 	"testing"
 
-	"github.com/servletcloud/Andmerada/internal/osutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func AssertFileContains(t *testing.T, path string, expected string) {
@@ -22,20 +19,4 @@ func AssertPlaceholdersResolved(t *testing.T, content string) {
 
 	assert.NotContains(t, content, "{{")
 	assert.NotContains(t, content, "}}")
-}
-
-func MkDir(t *testing.T, path string) {
-	t.Helper()
-
-	err := os.Mkdir(path, osutil.DirPerm0755)
-	require.NoError(t, err)
-}
-
-func ReadFileToString(t *testing.T, path string) string {
-	t.Helper()
-
-	bytes, err := os.ReadFile(path)
-	require.NoError(t, err)
-
-	return string(bytes)
 }

--- a/internal/tests/os.go
+++ b/internal/tests/os.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/servletcloud/Andmerada/internal/osutil"
+	"github.com/stretchr/testify/require"
+)
+
+func MkDir(t *testing.T, path string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(path)
+		require.NoError(t, err)
+	})
+
+	err := os.Mkdir(path, osutil.DirPerm0755)
+	require.NoError(t, err)
+}
+
+func ReadFileToString(t *testing.T, path string) string {
+	t.Helper()
+
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(bytes)
+}


### PR DESCRIPTION
Example:
```
./bin/andmerada migrate --database-url=postgres://andmerada:andmerada@localhost:5432/andmerada?sslmode=disable
2025/02/08 18:23:08 There are no migration files found. To create one, run:
andmerada create-migration "Add users table
```