### PR TITLE
Used plan SELECT instead of COPY protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,12 @@ lint-docker:
 
 test-with-race:
 	@echo "Running tests..."
-	go test -shuffle on -timeout=30s -race ./...
+	go test -shuffle on -timeout=60s -race ./...
 
 
 test:
 	@echo "Running tests..."
-	go test -shuffle on -timeout=30s ./...
+	go test -shuffle on -timeout=60s ./...
 
 
 clean:

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -36,7 +36,7 @@ func TestMigrationYMLTemplateMatchesSchema(t *testing.T) {
 
 	yamlFile := resources.TemplateMigrationYml("Create users table")
 
-	var yamlData map[string]interface{}
+	var yamlData map[string]any
 
 	require.NoError(t, yaml.Unmarshal([]byte(yamlFile), &yamlData))
 

--- a/internal/source/linters/configlinter.go
+++ b/internal/source/linters/configlinter.go
@@ -16,7 +16,7 @@ type ConfigLinter struct {
 	ProjectDir string
 }
 
-func (linter *ConfigLinter) Lint(relative string, configuration interface{}) bool {
+func (linter *ConfigLinter) Lint(relative string, configuration any) bool {
 	path := filepath.Join(linter.ProjectDir, relative)
 
 	err := ymlutil.LoadFromFile(path, schema.GetMigrationSchema(), configuration)

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -35,7 +35,7 @@ type Configuration struct {
 		BlockReason string `yaml:"block_reason"`
 	} `yaml:"down"`
 
-	Meta map[string]interface{} `yaml:"meta"`
+	Meta map[string]any `yaml:"meta"`
 }
 
 type LintConfiguration struct {

--- a/internal/ymlutil/validator.go
+++ b/internal/ymlutil/validator.go
@@ -27,16 +27,16 @@ func validate(yml []byte, schema string) (*gojsonschema.Result, error) {
 }
 
 func ymlToJSON(yml []byte) ([]byte, error) {
-	var yamlData map[string]interface{}
+	var yamlData map[string]any
 
 	if err := yaml.Unmarshal(yml, &yamlData); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal YML to map[string]interface{}: %w", err)
+		return nil, fmt.Errorf("cannot unmarshal YML to map[string]any: %w", err)
 	}
 
 	result, err := json.Marshal(yamlData)
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot marshal map[string]interface{} to JSON: %w", err)
+		return nil, fmt.Errorf("cannot marshal map[string]any to JSON: %w", err)
 	}
 
 	return result, nil

--- a/internal/ymlutil/ymlutil.go
+++ b/internal/ymlutil/ymlutil.go
@@ -31,7 +31,7 @@ func NewValidationError(result *gojsonschema.Result) *ValidationError {
 	return &ValidationError{validationResult: result}
 }
 
-func LoadFromFile(path string, schema string, out interface{}) error {
+func LoadFromFile(path string, schema string, out any) error {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("cannot read file %q: %w", path, err)


### PR DESCRIPTION
## Motivation

After measuring the elapsed time to fetch 1k, 10k, 100k and 1kk records I was not able to find a significant difference between `SELECT ` and `COPY` with text protocol. 

However, the `SELECT` is simpler code-wise. So sticking to it.

Maybe in the future, I will use `COPY` to binary protocol and will do the second round of performance comparison.