### PR TITLE
Use string instead of []byte for embedded resources

### DIFF
--- a/internal/cmd/descriptions/descriptions.go
+++ b/internal/cmd/descriptions/descriptions.go
@@ -10,16 +10,16 @@ const (
 )
 
 //go:embed init.txt
-var initRaw []byte
+var initRaw string
 
 //go:embed lint.txt
-var lintRaw []byte
+var lintRaw string
 
 //go:embed create_migration.txt
-var crMigrationRaw []byte
+var crMigrationRaw string
 
 //go:embed migrate.txt
-var migrateRaw []byte
+var migrateRaw string
 
 type CommandDescription struct {
 	Use   string
@@ -43,8 +43,8 @@ func MigrateDescription() CommandDescription {
 	return loadCommandDescription(migrateRaw)
 }
 
-func loadCommandDescription(s []byte) CommandDescription {
-	lines := strings.Split(string(s), unixNewLine)
+func loadCommandDescription(s string) CommandDescription {
+	lines := strings.Split(s, unixNewLine)
 
 	return CommandDescription{
 		Use:   lines[0],

--- a/internal/migrator/sqlres/sql.go
+++ b/internal/migrator/sqlres/sql.go
@@ -6,10 +6,8 @@ import (
 )
 
 //go:embed ddl.sql
-var ddlBytes []byte
+var ddl string
 
 func DDL(appliedMigrationsName string) string {
-	ddl := string(ddlBytes)
-
 	return strings.ReplaceAll(ddl, "_applied_migrations_", appliedMigrationsName)
 }

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -6,57 +6,57 @@ import (
 )
 
 //go:embed template.andmerada.yml
-var templateAndmeradaYml []byte
+var templateAndmeradaYml string
 
 //go:embed template.migration.yml
-var templateMigrationYml []byte
+var templateMigrationYml string
 
 //go:embed template.up.sql
-var templateUpSQL []byte
+var templateUpSQL string
 
 //go:embed template.down.sql
-var templateDownSQL []byte
+var templateDownSQL string
 
 //go:embed msg_init_completed.txt
-var msgInitCompleted []byte
+var msgInitCompleted string
 
 //go:embed msg_err_project_exists.txt
-var msgErrProjectExists []byte
+var msgErrProjectExists string
 
 //go:embed msg_migration_created.txt
-var msgMigrationCreated []byte
+var msgMigrationCreated string
 
 //go:embed msg_migration_not_latest.txt
-var msgMigrationNotLatest []byte
+var msgMigrationNotLatest string
 
 func TemplateAndmeradaYml(projectName string) string {
-	return strings.ReplaceAll(string(templateAndmeradaYml), "{{project_name}}", projectName)
+	return strings.ReplaceAll(templateAndmeradaYml, "{{project_name}}", projectName)
 }
 
 func TemplateMigrationYml(name string) string {
-	return strings.ReplaceAll(string(templateMigrationYml), "{{name}}", name)
+	return strings.ReplaceAll(templateMigrationYml, "{{name}}", name)
 }
 
 func TemplateUpSQL() string {
-	return string(templateUpSQL)
+	return templateUpSQL
 }
 
 func TemplateDownSQL() string {
-	return string(templateDownSQL)
+	return templateDownSQL
 }
 
 func MsgInitCompleted() string {
-	return string(msgInitCompleted)
+	return msgInitCompleted
 }
 
 func MsgErrProjectExists() string {
-	return string(msgErrProjectExists)
+	return msgErrProjectExists
 }
 
 func MsgMigrationCreated(dir string) string {
-	return strings.ReplaceAll(string(msgMigrationCreated), "{{dir}}", dir)
+	return strings.ReplaceAll(msgMigrationCreated, "{{dir}}", dir)
 }
 
 func MsgMigrationNotLatest() string {
-	return string(msgMigrationNotLatest)
+	return msgMigrationNotLatest
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -5,15 +5,15 @@ import (
 )
 
 //go:embed migration.yml.v1.json
-var migrationSchema []byte
+var migrationSchema string
 
 //go:embed andmerada.yml.v1.json
-var andmeradaSchema []byte
+var andmeradaSchema string
 
 func GetMigrationSchema() string {
-	return string(migrationSchema)
+	return migrationSchema
 }
 
 func GetAndmeradaSchema() string {
-	return string(andmeradaSchema)
+	return andmeradaSchema
 }


### PR DESCRIPTION
Use string instead of []byte for embedded resources

Reasons:
1. Avoids redundant []byte → string conversions
2. More idiomatic use of Go's embed capabilities