### PR TITLE
Project name was removed as redundant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ go.work.sum
 .env
 
 andmerada.yml
+
+.vscode/

--- a/internal/migrator/applier.go
+++ b/internal/migrator/applier.go
@@ -57,7 +57,7 @@ func (applier *Applier) ApplyPending(ctx context.Context, report *Report) error 
 
 	defer func() { _ = connection.Close(ctx) }()
 
-	ddl := sqlres.DDL(applier.Project.Configuration.TableNames.AppliedMigrations)
+	ddl := sqlres.DDL(applier.migrationsTableName())
 
 	if err := execSimple(ctx, connection.PgConn(), ddl); err != nil {
 		return wrapError(&ExecSQLError{Cause: err, SQL: ddl}, ErrTypeCreateDDL)
@@ -195,7 +195,6 @@ func (applier *Applier) registerMigration(
 
 	args := pgx.NamedArgs{
 		"id":               id,
-		"project":          applier.Project.Configuration.Name,
 		"name":             source.Configuration.Name,
 		"applied_at":       time.Now().UTC(),
 		"sql_up":           source.UpSQL,
@@ -229,5 +228,5 @@ func (applier *Applier) getSortedMigrationIDs(sourceIDToName map[source.Migratio
 }
 
 func (applier *Applier) migrationsTableName() string {
-	return applier.Project.Configuration.TableNames.AppliedMigrations
+	return applier.Project.Configuration.MigrationsTableName
 }

--- a/internal/migrator/sqlres/ddl.sql
+++ b/internal/migrator/sqlres/ddl.sql
@@ -1,6 +1,5 @@
-CREATE TABLE IF NOT EXISTS "_applied_migrations_" (
+CREATE TABLE IF NOT EXISTS "_table_name_" (
     id BIGINT PRIMARY KEY, -- The unique migration ID (e.g., a timestamp like 20241225112129)
-    project TEXT NOT NULL CHECK (char_length(name) <= 255),
     name TEXT NOT NULL CHECK (char_length(name) <= 255),
     applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
     sql_up TEXT NOT NULL CHECK (char_length(sql_up) <= 1000000),

--- a/internal/migrator/sqlres/register-migration.sql
+++ b/internal/migrator/sqlres/register-migration.sql
@@ -1,6 +1,5 @@
-INSERT INTO __table_name__ (
+INSERT INTO _table_name_ (
     id,
-    project,
     name,
     applied_at,
     sql_up,
@@ -12,7 +11,6 @@ INSERT INTO __table_name__ (
     meta
 ) VALUES (
     @id,
-    @project,
     @name,
     @applied_at,
     @sql_up,
@@ -24,7 +22,6 @@ INSERT INTO __table_name__ (
     @meta
 )
 ON CONFLICT (id) DO UPDATE SET
-    project = EXCLUDED.project,
     name = EXCLUDED.name,
     applied_at = EXCLUDED.applied_at,
     sql_up = EXCLUDED.sql_up,

--- a/internal/migrator/sqlres/sql.go
+++ b/internal/migrator/sqlres/sql.go
@@ -11,10 +11,10 @@ var ddl string
 //go:embed register-migration.sql
 var registerMigrationQuery string
 
-func DDL(appliedMigrationsName string) string {
-	return strings.ReplaceAll(ddl, "_applied_migrations_", appliedMigrationsName)
+func DDL(tableName string) string {
+	return strings.ReplaceAll(ddl, "_table_name_", tableName)
 }
 
 func RegisterMigrationQuery(tableName string) string {
-	return strings.ReplaceAll(registerMigrationQuery, "__table_name__", tableName)
+	return strings.ReplaceAll(registerMigrationQuery, "_table_name_", tableName)
 }

--- a/internal/project/initializer.go
+++ b/internal/project/initializer.go
@@ -5,25 +5,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"unicode/utf8"
 
 	"github.com/servletcloud/Andmerada/internal/osutil"
 	"github.com/servletcloud/Andmerada/internal/resources"
 )
 
 func initialize(dir string) error {
-	projectName := filepath.Base(dir)
-	if utf8.RuneCountInString(projectName) > MaxNameLength {
-		return ErrNameExceeds255
-	}
-
 	if err := os.MkdirAll(dir, osutil.DirPerm0755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
 	configPath := filepath.Join(dir, rootConfigFilename)
 
-	content := resources.TemplateAndmeradaYml(projectName)
+	content := resources.TemplateAndmeradaYml()
 
 	if err := osutil.WriteFileExcl(configPath, content); err != nil {
 		if errors.Is(err, os.ErrExist) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -13,11 +13,7 @@ type Project struct {
 }
 
 type Configuration struct {
-	Name string `yaml:"name"`
-
-	TableNames struct {
-		AppliedMigrations string `yaml:"applied_migrations"`
-	} `yaml:"table_names"`
+	MigrationsTableName string `yaml:"migrations_table_name"`
 }
 
 var (

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/servletcloud/Andmerada/internal/osutil"
 	"github.com/servletcloud/Andmerada/internal/project"
-	"github.com/servletcloud/Andmerada/internal/tests"
 	"github.com/servletcloud/Andmerada/internal/ymlutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +16,7 @@ import (
 func TestInitialize(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Create directory, configuration file, resolves configuration placeholders", func(t *testing.T) {
+	t.Run("Create directory, configuration file", func(t *testing.T) {
 		t.Parallel()
 
 		projectDir := filepath.Join(t.TempDir(), "migrations/main_db_project")
@@ -25,8 +24,7 @@ func TestInitialize(t *testing.T) {
 		require.NoError(t, project.Initialize(projectDir))
 
 		assert.DirExists(t, projectDir)
-
-		tests.AssertFileContains(t, filepath.Join(projectDir, "andmerada.yml"), `name: "main_db_project"`)
+		assert.FileExists(t, filepath.Join(projectDir, "andmerada.yml"))
 	})
 
 	t.Run("Returns specific error it target project does already exist", func(t *testing.T) {
@@ -57,8 +55,7 @@ func TestLoad(t *testing.T) {
 		configuration := project.Configuration
 
 		assert.Equal(t, projectDir, project.Dir)
-		assert.Equal(t, filepath.Base(projectDir), configuration.Name)
-		assert.Equal(t, "applied_migrations", configuration.TableNames.AppliedMigrations)
+		assert.Equal(t, "migrations", configuration.MigrationsTableName)
 	})
 
 	t.Run("returns os.ErrNotExist when project dir does not exist", func(t *testing.T) {

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -29,8 +29,8 @@ var msgMigrationCreated string
 //go:embed msg_migration_not_latest.txt
 var msgMigrationNotLatest string
 
-func TemplateAndmeradaYml(projectName string) string {
-	return strings.ReplaceAll(templateAndmeradaYml, "{{project_name}}", projectName)
+func TemplateAndmeradaYml() string {
+	return templateAndmeradaYml
 }
 
 func TemplateMigrationYml(name string) string {

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -13,15 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestTemplateAndmeradaYml(t *testing.T) {
-	t.Parallel()
-
-	content := resources.TemplateAndmeradaYml("maindb")
-
-	assert.Contains(t, content, `name: "maindb"`)
-	tests.AssertPlaceholdersResolved(t, content)
-}
-
 func TestTemplateMigrationYml(t *testing.T) {
 	t.Parallel()
 

--- a/internal/resources/template.andmerada.yml
+++ b/internal/resources/template.andmerada.yml
@@ -2,7 +2,4 @@
 # yamllint disable rule:line-length
 # yaml-language-server: $schema=https://raw.githubusercontent.com/servletcloud/Andmerada/refs/heads/main/internal/schema/andmerada.yml.v1.json
 # yamllint enable
-name: "{{project_name}}"
-
-table_names:
-  applied_migrations: applied_migrations
+migrations_table_name: migrations

--- a/internal/schema/andmerada.yml.v1.json
+++ b/internal/schema/andmerada.yml.v1.json
@@ -2,26 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Project Configuration",
   "type": "object",
-  "required": ["name", "table_names"],
+  "required": ["migrations_table_name"],
   "properties": {
-    "name": {
+    "migrations_table_name": {
       "type": "string",
-      "description": "The name of the project",
+      "description": "The name of the table that stores applied migrations",
       "minLength": 1,
       "maxLength": 255
-    },
-    "table_names": {
-      "type": "object",
-      "description": "Database table names used by Andmerada",
-      "required": ["applied_migrations"],
-      "properties": {
-        "applied_migrations": {
-          "type": "string",
-          "description": "The name of the table that stores applied migrations",
-          "minLength": 1,
-          "maxLength": 255
-        }
-      }
     }
   }
 }

--- a/internal/source/scanner.go
+++ b/internal/source/scanner.go
@@ -27,10 +27,12 @@ func scan(projectDir string, callback func(id MigrationID, name string) bool) er
 		name := entry.Name()
 		id := NewIDFromString(name)
 
-		if id != EmptyMigrationID {
-			if !callback(id, name) {
-				break
-			}
+		if id == EmptyMigrationID {
+			continue
+		}
+
+		if !callback(id, name) {
+			break
 		}
 	}
 


### PR DESCRIPTION
It is supposed to have a separate migrations table per project/per schema for the sake of simplification.