### PR TITLE
Upgrade golangci-lint from v1.62.2 to v2.1.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,69 +1,87 @@
----
+version: "2"
 linters:
-  enable-all: true
-  disable:
-    - exportloopref
-    - gofumpt
-
-linters-settings:
-  varnamelen:
-    min-name-length: 3
-    ignore-names:
-      - sb
-      - id
-      - db
-  tagliatelle:
-    case:
+  default: all
+  settings:
+    depguard:
       rules:
-        yaml: snake
-  depguard:
-    rules:
-      main:
-        allow:
-          - bufio
-          - bytes
-          - cmp
-          - context
-          - crypto/sha256
-          - embed
-          - encoding/hex
-          - encoding/json
-          - errors
-          - fmt
-          - github.com/dustin/go-humanize
-          - github.com/expr-lang/expr
-          - github.com/expr-lang/expr/vm
-          - github.com/fergusstrange/embedded-postgres
-          - github.com/jackc/pgerrcode
-          - github.com/jackc/pgx/v5
-          - github.com/servletcloud/Andmerada/internal/cmd
-          - github.com/servletcloud/Andmerada/internal/migrator
-          - github.com/servletcloud/Andmerada/internal/osutil
-          - github.com/servletcloud/Andmerada/internal/project
-          - github.com/servletcloud/Andmerada/internal/resources
-          - github.com/servletcloud/Andmerada/internal/schema
-          - github.com/servletcloud/Andmerada/internal/source
-          - github.com/servletcloud/Andmerada/internal/tests
-          - github.com/servletcloud/Andmerada/internal/ymlutil
-          - github.com/spf13/cobra
-          - github.com/stretchr/testify/assert
-          - github.com/stretchr/testify/require
-          - github.com/xeipuuv/gojsonschema
-          - gopkg.in/yaml.v3
-          - io
-          - iter
-          - log
-          - maps
-          - math
-          - net
-          - net/url
-          - os
-          - path/filepath
-          - regexp
-          - slices
-          - sort
-          - strconv
-          - strings
-          - testing
-          - time
-          - unicode
+        main:
+          allow:
+            - bufio
+            - bytes
+            - cmp
+            - context
+            - crypto/sha256
+            - embed
+            - encoding/hex
+            - encoding/json
+            - errors
+            - fmt
+            - github.com/dustin/go-humanize
+            - github.com/expr-lang/expr
+            - github.com/expr-lang/expr/vm
+            - github.com/fergusstrange/embedded-postgres
+            - github.com/jackc/pgerrcode
+            - github.com/jackc/pgx/v5
+            - github.com/servletcloud/Andmerada/internal/cmd
+            - github.com/servletcloud/Andmerada/internal/migrator
+            - github.com/servletcloud/Andmerada/internal/osutil
+            - github.com/servletcloud/Andmerada/internal/project
+            - github.com/servletcloud/Andmerada/internal/resources
+            - github.com/servletcloud/Andmerada/internal/schema
+            - github.com/servletcloud/Andmerada/internal/source
+            - github.com/servletcloud/Andmerada/internal/tests
+            - github.com/servletcloud/Andmerada/internal/ymlutil
+            - github.com/spf13/cobra
+            - github.com/stretchr/testify/assert
+            - github.com/stretchr/testify/require
+            - github.com/xeipuuv/gojsonschema
+            - gopkg.in/yaml.v3
+            - io
+            - iter
+            - log
+            - maps
+            - math
+            - net
+            - net/url
+            - os
+            - path/filepath
+            - regexp
+            - slices
+            - sort
+            - strconv
+            - strings
+            - testing
+            - time
+            - unicode
+    tagliatelle:
+      case:
+        rules:
+          yaml: snake
+    varnamelen:
+      min-name-length: 3
+      ignore-names:
+        - sb
+        - id
+        - db
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAIN_FILE := cmd/$(APP_NAME)/main.go
 EXECUTABLE := $(BUILD_DIR)/$(APP_NAME)
 
 GOLANG_BIN := $(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION := v1.62.2
+GOLANGCI_LINT_VERSION := v2.1.2
 
 
 .PHONY: all ci run build clean fmt test test-with-race lint check-fmt install-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/servletcloud/Andmerada
 
-go 1.23.4
+go 1.24.1
 
 require github.com/spf13/cobra v1.8.1
 

--- a/internal/cmd/pgerrortranslator.go
+++ b/internal/cmd/pgerrortranslator.go
@@ -51,7 +51,7 @@ func (translator *pgErrorTranslator) writeKv(sb *strings.Builder, key, value str
 		return
 	}
 
-	sb.WriteString(fmt.Sprintf("%s: %s\n", key, value))
+	fmt.Fprintf(sb, "%s: %s\n", key, value)
 }
 
 func (translator *pgErrorTranslator) highlightSQLPosition(sql string, pos int) (int, int, string) {

--- a/internal/osutil/files.go
+++ b/internal/osutil/files.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	//nolint:stylecheck,revive
+	//nolint:revive
 	O_CREATE_EXCL_WRONLY = os.O_CREATE | os.O_EXCL | os.O_WRONLY
 
 	FilePerm0644 = 0644 // Owner: read/write, Group/Others: read

--- a/internal/osutil/files_test.go
+++ b/internal/osutil/files_test.go
@@ -56,5 +56,5 @@ func TestNormalizePath(t *testing.T) {
 	assert.Equal(t, "add_flags_table", osutil.NormalizePath("Add   FLAGS  Table"))
 	assert.Equal(t, "add_type_column", osutil.NormalizePath("~ADD!!Type^^Column@@"))
 	assert.Equal(t, "add.one-two_three", osutil.NormalizePath("add.one-two_three"))
-	assert.Equal(t, "", osutil.NormalizePath("~!@#$%^&*()"))
+	assert.Empty(t, osutil.NormalizePath("~!@#$%^&*()"))
 }

--- a/internal/source/linter.go
+++ b/internal/source/linter.go
@@ -12,6 +12,14 @@ type linter struct {
 	report *LintReport
 }
 
+func (linter *linter) AddError(title string, files ...string) {
+	linter.report.Errors = append(linter.report.Errors, LintError{Title: title, Files: files})
+}
+
+func (linter *linter) AddWarning(title string, files ...string) {
+	linter.report.Warings = append(linter.report.Warings, LintError{Title: title, Files: files})
+}
+
 func (linter *linter) lint() error {
 	duplicatesLinter := linters.NewDupeLinter(linter)
 	defer duplicatesLinter.Report()
@@ -77,12 +85,4 @@ func (linter *linter) newFutureLinter() *linters.FutureLinter {
 		Reporter:  linter,
 		Threshold: newIDFromTime(linter.NowUTC),
 	}
-}
-
-func (linter *linter) AddError(title string, files ...string) {
-	linter.report.Errors = append(linter.report.Errors, LintError{Title: title, Files: files})
-}
-
-func (linter *linter) AddWarning(title string, files ...string) {
-	linter.report.Warings = append(linter.report.Warings, LintError{Title: title, Files: files})
 }

--- a/internal/tests/assert.go
+++ b/internal/tests/assert.go
@@ -1,23 +1,22 @@
 package tests
 
 import (
-	"context"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 )
 
-func AssertPgTableExist(ctx context.Context, t *testing.T, conn *pgx.Conn, tableName string) {
+func AssertPgTableExist(t *testing.T, conn *pgx.Conn, tableName string) {
 	t.Helper()
 
-	assert.True(t, isPgTableExist(ctx, t, conn, tableName), "Table %s does not exist", tableName)
+	assert.True(t, isPgTableExist(t, conn, tableName), "Table %s does not exist", tableName)
 }
 
-func AssertPgTableNotExist(ctx context.Context, t *testing.T, conn *pgx.Conn, tableName string) {
+func AssertPgTableNotExist(t *testing.T, conn *pgx.Conn, tableName string) {
 	t.Helper()
 
-	assert.False(t, isPgTableExist(ctx, t, conn, tableName), "Table %s exists", tableName)
+	assert.False(t, isPgTableExist(t, conn, tableName), "Table %s exists", tableName)
 }
 
 func AssertFileContains(t *testing.T, path string, expected string) {

--- a/internal/tests/pg.go
+++ b/internal/tests/pg.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"testing"
@@ -37,7 +36,7 @@ func StartEmbeddedPostgres(t *testing.T) ConnectionURL {
 func OpenPgConnection(t *testing.T, url ConnectionURL) *pgx.Conn {
 	t.Helper()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn, err := pgx.Connect(ctx, string(url))
 	require.NoError(t, err)
 
@@ -63,12 +62,12 @@ func GetRandomAvailablePort(t *testing.T) uint32 {
 	return uint32(addr.Port) //nolint:gosec
 }
 
-func isPgTableExist(ctx context.Context, t *testing.T, conn *pgx.Conn, name string) bool {
+func isPgTableExist(t *testing.T, conn *pgx.Conn, name string) bool {
 	t.Helper()
 
 	query := fmt.Sprintf("select * from %v limit 1;", name)
 
-	_, err := conn.Exec(ctx, query)
+	_, err := conn.Exec(t.Context(), query)
 
 	if err == nil {
 		return true

--- a/internal/ymlutil/ymlutil.go
+++ b/internal/ymlutil/ymlutil.go
@@ -14,6 +14,10 @@ type ValidationError struct {
 	validationResult *gojsonschema.Result
 }
 
+func NewValidationError(result *gojsonschema.Result) *ValidationError {
+	return &ValidationError{validationResult: result}
+}
+
 func (e *ValidationError) Error() string {
 	var stringBuilder strings.Builder
 
@@ -22,10 +26,6 @@ func (e *ValidationError) Error() string {
 	}
 
 	return strings.TrimSpace(stringBuilder.String())
-}
-
-func NewValidationError(result *gojsonschema.Result) *ValidationError {
-	return &ValidationError{validationResult: result}
 }
 
 func LoadFromFile(path string, schema string, out any) error {


### PR DESCRIPTION
Go 1.24.1 is now required with updated testing patterns using t.Context().

AI: I've analyzed the changes and written a concise commit message focused on the golangci-lint upgrade and Go version requirement change. The commit also includes updates to testing patterns that use the newer t.Context() approach. I kept the subject line under 50 characters and didn't include a message body since the subject adequately summarizes the changes.